### PR TITLE
Fix tilde card name replacement

### DIFF
--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -2286,7 +2286,7 @@ function writeText(textObject, targetContext) {
 		rawText = params.get('copyright'); //so people using CC for custom card games without WotC's IP can customize their copyright info
 		if (rawText == 'none') { rawText = ''; }
 	}
-	if (rawText.toLowerCase().includes('{cardname}' || '~')) {
+	if (rawText.toLowerCase().includes('{cardname}') || rawText.toLowerCase().includes('~')) {
 		rawText = rawText.replace(/{cardname}|~/ig, getCardName());
 	}
 	if (document.querySelector('#info-artist').value == '') {


### PR DESCRIPTION
The tilde replacement for card name doesn't work if the "{cardname}" tag isn't present because the if condition is incorrect.  This fixes the condition to check for either one.