### PR TITLE
Allow Saga abilities to have no chapters

### DIFF
--- a/js/frames/versionSaga.js
+++ b/js/frames/versionSaga.js
@@ -92,7 +92,7 @@ function sagaEdited() {
 				sagaContext.fillText(romanNumeral(sagaCount), numeralTextX, numeralTextY - numeralTextSpread);
 				sagaContext.fillText(romanNumeral(sagaCount + 1), numeralTextX, numeralTextY + numeralTextSpread);
 				sagaCount += 2;
-			} else {
+			} else if (card.saga.abilities[i] > 2) {
 				var numeralSpread = 2 * scaleHeight(0.0358);
 				var numeralTextSpread = 2 * scaleHeight(0.0358);
 				sagaContext.drawImage(sagaChapter, numeralX, numeralY - numeralSpread, numeralWidth, numeralHeight);


### PR DESCRIPTION
Abilities on Sagas now correctly display no chapter markers if the chapter count is set to 0

Seen on the card "Greatest Show in the Multiverse" from Unfinity:
![Greatest Show in the Multiverse](https://gatherer.wizards.com/Handlers/Image.ashx?multiverseid=580820&type=card)