### PR TITLE
Fix initiative token path

### DIFF
--- a/js/frames/packTokenInitiative.js
+++ b/js/frames/packTokenInitiative.js
@@ -1,6 +1,6 @@
 //defines available frames
 availableFrames = [
-	{name:'Initiative Frame', src:'/img/frames/token/Initiative/initiative.png'}
+	{name:'Initiative Frame', src:'/img/frames/token/initiative/initiative.png'}
 ];
 //disables/enables the "Load Frame Version" button
 document.querySelector('#loadFrameVersion').disabled = false;


### PR DESCRIPTION
The path seems to be case sensitive, so the initiative token couldn't be loaded on the current live version.