### PR TITLE
fix: add `url` search param to corsproxy.io service

### DIFF
--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -5299,7 +5299,7 @@ function imageURL(url, destination, otherParams) {
 	} else if (params.get('noproxy') != '') {
 		//CORS PROXY LINKS
 		//Previously: https://cors.bridged.cc/
-		imageurl = 'https://corsproxy.io/?' + encodeURIComponent(url);
+		imageurl = 'https://corsproxy.io/?url=' + encodeURIComponent(url);
 	}
 	destination(imageurl, otherParams);
 }


### PR DESCRIPTION
This pull request includes a small fix to the `imageURL` function. The change updates the CORS proxy URL format to include the `url=` parameter, ensuring proper functionality.

