### PR TITLE
use textContent for frameSearch options

### DIFF
--- a/js/frameSearch.js
+++ b/js/frameSearch.js
@@ -287,7 +287,7 @@ function autocomplete(inp, arr) {
 				b.setAttribute("class", "input")
 				b.innerHTML = arr[i];
 				b.addEventListener("click", function(e) {
-					inp.value = this.innerHTML;
+					inp.value = this.textContent;
 					frameSearch(inp.value);
               		closeAllLists();
           		});


### PR DESCRIPTION
This fixes an issue specifically with the D&D frame where the & was being injected with the html version `&amp;`.
This will be robust to future symbols also.