### PR TITLE
defer loading the default pack to fix fonts

### DIFF
--- a/js/frames/packM15Regular-1.js
+++ b/js/frames/packM15Regular-1.js
@@ -55,5 +55,5 @@ document.querySelector('#loadFrameVersion').onclick = async function() {
 loadFramePack();
 //Only for the main version as the webpage loads:
 if (!card.text) {
-	document.querySelector('#loadFrameVersion').click();
+	setTimeout(() => document.querySelector('#loadFrameVersion').click());
 }


### PR DESCRIPTION
This PR fixes a problem with the initial page load. The fonts aren't loaded correctly and the existing code that was meant to fix it does not. Wrapping it in a timeout to defer it to the next event loop seems to fix it reliably.