### PR TITLE
Fixes Class Header Behavior

### DIFF
--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -4618,7 +4618,7 @@ function drawCard() {
 	// custom elements for sagas, classes, and dungeons
 	if (card.version.toLowerCase().includes('saga') && typeof sagaCanvas !== "undefined") {
 		cardContext.drawImage(sagaCanvas, 0, 0, cardCanvas.width, cardCanvas.height);
-	} else if (card.version.toLowerCase().includes('class') && typeof classCanvas !== "undefined") {
+	} else if (card.version.includes('class') && !card.version.includes('classic') && typeof classCanvas !== "undefined") {
 		cardContext.drawImage(classCanvas, 0, 0, cardCanvas.width, cardCanvas.height);
 	} else if (card.version.toLowerCase().includes('dungeon') && typeof dungeonCanvas !== "undefined") {
 		cardContext.drawImage(dungeonCanvas, 0, 0, cardCanvas.width, cardCanvas.height);

--- a/js/frames/groupMargin.js
+++ b/js/frames/groupMargin.js
@@ -55,7 +55,7 @@ var loadMarginVersion = async () => {
 	if (card.version.includes('saga')) {
 		sagaEdited();
 	}
-	if (card.version.includes('class') && !card.version.includes('classicshifted')) {
+	if (card.version.includes('class')) {
 		classEdited();
 	}
 	drawTextBuffer();


### PR DESCRIPTION
Fixes the check for class that is causing ClassicShifted frame set to be seen as a class and load the class header. This happens currently if the class tab has been created prior to switching to one of those frames. It was being removed in margin tab before but now the header doesn't get applied to any frame with 'classic' in the card.verson.

To see this issue go to the Regular > Class (D&D) and then switch to one of the  Custom > ClassicShifted series frames. Header remains drawn on screen.