### PR TITLE
Fixes Unwanted margin behavior with ClassicShifted

### DIFF
--- a/js/frames/groupMargin.js
+++ b/js/frames/groupMargin.js
@@ -55,7 +55,7 @@ var loadMarginVersion = async () => {
 	if (card.version.includes('saga')) {
 		sagaEdited();
 	}
-	if (card.version.includes('class')) {
+	if (card.version.includes('class') && !card.version.includes('classic')) {
 		classEdited();
 	}
 	drawTextBuffer();


### PR DESCRIPTION
Fixes an issue where ClassicShifted frames don't want to expand the canvas (and if you mess with the layers it unrenders the text for the card) for margin by adding a class exception to the margin group. (This exception was previously here but appeared to work from my pr to move it to where classes were handled in creator23 but apparently it needs to be in both places). Before this was classicshifted in the margin and now I made it just classic to also account for any frames that would have classic in the frame version to not get treated like this when switching to margin.