### PR TITLE
Saga Ability Import Proportions

### DIFF
--- a/js/frames/versionSaga.js
+++ b/js/frames/versionSaga.js
@@ -133,12 +133,12 @@ function updateAbilityHeights() {
 	
 	// Add height constraint (minimum height)
 	const minHeight = maxHeight * 0.15; // 15% of max height
+	let availableHeight = maxHeight - (minHeight * abilities.length);
 	abilities.forEach(ability => {
-	const height = Math.max(
-		minHeight,
-		(ability.wordCount / totalWords) * maxHeight
-	);
-	card.text[`ability${ability.index}`].height = height;
+		const height = minHeight + (
+			(ability.wordCount / totalWords) * availableHeight
+		);
+		card.text[`ability${ability.index}`].height = height;
 	});
 
 	// Set remaining abilities to 0 height

--- a/js/frames/versionSaga.js
+++ b/js/frames/versionSaga.js
@@ -62,13 +62,13 @@ function sagaEdited() {
 	card.saga.count = 0;
 	var lastY = card.text.ability0.y;
 	for (var i = 0; i < 4; i ++) {
-	 	card.text['ability' + i].y = lastY;
-	 	var height = parseFloat((parseInt(document.querySelector('#saga-height-' + i).value) / card.height).toFixed(4));
-	 	if (height > 0) {
-	 		card.saga.count ++;
-	 	}
-	 	card.text['ability' + i].height = height;
-	 	lastY += height;
+		card.text['ability' + i].y = lastY;
+		var height = parseFloat((parseInt(document.querySelector('#saga-height-' + i).value) / card.height).toFixed(4));
+		if (height > 0) {
+			card.saga.count ++;
+		}
+		card.text['ability' + i].height = height;
+		lastY += height;
 	}
 	fixSagaInputs();
 	//draw to saga canvas
@@ -114,40 +114,40 @@ function updateAbilityHeights() {
 	// Get all saga abilities that have content
 	const abilities = [];
 	for (let i = 0; i < card.saga.count; i++) {
-	  const abilityText = card.text[`ability${i}`].text;
-	  // Count words excluding reminder text in parentheses
-	  const wordCount = abilityText
+	const abilityText = card.text[`ability${i}`].text;
+	// Count words excluding reminder text in parentheses
+	const wordCount = abilityText
 		.replace(/\([^)]*\)/g, '') // Remove reminder text
 		.trim()
 		.split(/\s+/)
 		.length;
 		
-	  abilities.push({
+	abilities.push({
 		index: i,
 		wordCount: wordCount
-	  });
+	});
 	}
-  
+
 	// Calculate proportional heights
 	const totalWords = abilities.reduce((sum, a) => sum + a.wordCount, 0);
 	
 	// Add height constraint (minimum height)
 	const minHeight = maxHeight * 0.15; // 15% of max height
 	abilities.forEach(ability => {
-	  const height = Math.max(
-	    minHeight,
-	    (ability.wordCount / totalWords) * maxHeight
-	  );
-	  card.text[`ability${ability.index}`].height = height;
+	const height = Math.max(
+		minHeight,
+		(ability.wordCount / totalWords) * maxHeight
+	);
+	card.text[`ability${ability.index}`].height = height;
 	});
-  
+
 	// Set remaining abilities to 0 height
 	for (let i = card.saga.count; i < 4; i++) {
-	  card.text[`ability${i}`].height = 0;
+	card.text[`ability${i}`].height = 0;
 	}
-  
+
 	fixSagaInputs(sagaEdited);
-  }
+}
 
 function fixSagaInputs(callback) {
 	document.querySelector('#saga-height-0').value = scaleHeight(card.text.ability0.height);

--- a/js/frames/versionSaga.js
+++ b/js/frames/versionSaga.js
@@ -110,17 +110,44 @@ function sagaEdited() {
 
 function updateAbilityHeights() {
 	const maxHeight = card.text.type.y - card.text.ability0.y;
-	const height = maxHeight / card.saga.count;
-	card.text.ability0.height = 0
-	card.text.ability1.height = 0
-	card.text.ability2.height = 0
-	card.text.ability2.height = 0
+	
+	// Get all saga abilities that have content
+	const abilities = [];
 	for (let i = 0; i < card.saga.count; i++) {
-		card.text[`ability${i}`].height = height;
+	  const abilityText = card.text[`ability${i}`].text;
+	  // Count words excluding reminder text in parentheses
+	  const wordCount = abilityText
+		.replace(/\([^)]*\)/g, '') // Remove reminder text
+		.trim()
+		.split(/\s+/)
+		.length;
+		
+	  abilities.push({
+		index: i,
+		wordCount: wordCount
+	  });
 	}
-
+  
+	// Calculate proportional heights
+	const totalWords = abilities.reduce((sum, a) => sum + a.wordCount, 0);
+	
+	// Add height constraint (minimum height)
+	const minHeight = maxHeight * 0.15; // 15% of max height
+	abilities.forEach(ability => {
+	  const height = Math.max(
+	    minHeight,
+	    (ability.wordCount / totalWords) * maxHeight
+	  );
+	  card.text[`ability${ability.index}`].height = height;
+	});
+  
+	// Set remaining abilities to 0 height
+	for (let i = card.saga.count; i < 4; i++) {
+	  card.text[`ability${i}`].height = 0;
+	}
+  
 	fixSagaInputs(sagaEdited);
-}
+  }
 
 function fixSagaInputs(callback) {
 	document.querySelector('#saga-height-0').value = scaleHeight(card.text.ability0.height);


### PR DESCRIPTION
Changes from the even distribution of saga abilities to be based on the word count of each ability down to 15% minimum size ability. This ignores any reminder text for word counts.