### PR TITLE
Fixes shadows and outline scaling

### DIFF
--- a/js/frames/packJapanShowcase.js
+++ b/js/frames/packJapanShowcase.js
@@ -73,14 +73,14 @@ document.querySelector('#loadFrameVersion').onclick = async function() {
 	card.artBounds = {x:0, y:0, width:1, height:0.9224};
 	autoFitArt();
 	//set symbol bounds
-	card.setSymbolBounds = {x:0.91, y:0.635, width:0.12, height:0.0410, vertical:'center', horizontal: 'right', outlineWidth:1.001, outlineColor:'black'};
+	card.setSymbolBounds = {x:0.91, y:0.635, width:0.12, height:0.0410, vertical:'center', horizontal: 'right', outlineWidth:0.003, outlineColor:'black'};
 	resetSetSymbol();
 	//watermark bounds
 	card.watermarkBounds = {x:0.5, y:0.7762, width:0.75, height:0.2305};
 	resetWatermark();
 	//text
 	loadTextOptions({
-		mana: {name:'Mana Cost', text:'', y:0.0683, width:0.9190, height:71/2100, oneLine:true, size:71/1638, align:'right', outlineWidth:0.008, manaCost:true, manaSpacing:0,},
+		mana: {name:'Mana Cost', text:'', y:0.0683, width:0.9190, height:71/2100, oneLine:true, size:71/1638, align:'right', outlineWidth:0.010, manaCost:true, manaSpacing:0,},
 		title: {name:'Title', text:'', x:0.0854, y:0.0522, width:0.8292, height:0.0543, oneLine:true, font:'belerenb', size:0.0381, outlineWidth:0.008, color:'white'},
 		type: {name:'Type', text:'', x:0.0854, y:0.612, width:0.71, height:0.0543, oneLine:true, font:'belerenb', size:0.0279, outlineWidth:0.008, color:'white'},
 		rules: {name:'Rules Text', text:'', x:0.086, y:0.692, width:0.771, height:0.206, size:0.033, outlineWidth:0.008, font:'Plantin MT Pro', color:'white'},


### PR DESCRIPTION
Put all mana symbol rendering together so that we don't render them twice (we were before for shadow). Also makes more explicit check for outlines before changing how mana symbols are handled vs how they were. Updates the scaling on outlines to mirror how the text is outlined. Also changes the outline on set symbols to use the same type of rendering as the mana symbol outline and fixes the scaling of it as well so that it scales the same as the outline on everything else. This should help unify the outline for everything.