### PR TITLE
Restores Fake Shadow for Safari

### DIFF
--- a/js/frames/packJapanShowcaseNicknames.js
+++ b/js/frames/packJapanShowcaseNicknames.js
@@ -24,14 +24,14 @@ document.querySelector('#loadFrameVersion').onclick = async function() {
 	card.artBounds = {x:0, y:0, width:1, height:0.9224};
 	autoFitArt();
 	//set symbol bounds
-	card.setSymbolBounds = {x:0.91, y:0.635, width:0.12, height:0.0410, vertical:'center', horizontal: 'right', outlineWidth:1.001, outlineColor:'black'};
+	card.setSymbolBounds = {x:0.91, y:0.635, width:0.12, height:0.0410, vertical:'center', horizontal: 'right', outlineWidth:0.003, outlineColor:'black'};
 	resetSetSymbol();
 	//watermark bounds
 	card.watermarkBounds = {x:0.5, y:0.7762, width:0.75, height:0.2305};
 	resetWatermark();
 	//text
 loadTextOptions({
-		mana: {name:'Mana Cost', text:'', y:0.0683, width:0.9190, height:71/2100, oneLine:true, size:71/1638, align:'right', outlineWidth:0.008, manaCost:true, manaSpacing:0,},
+		mana: {name:'Mana Cost', text:'', y:0.0683, width:0.9190, height:71/2100, oneLine:true, size:71/1638, align:'right', outlineWidth:0.010, manaCost:true, manaSpacing:0,},
 		nickname: {name:'Nickname', text:'', x:0.090, y:0.0582, width:0.8292, height:0.0543, outlineWidth:0.008, oneLine:true, font:'belerenb', size:0.0381, color:'white',},
 		title: {name:'Title', text:'', x:0.14, y:0.1200, width:0.768, height:0.0243, oneLine:true, outlineWidth:0.0065, font:'mplantini', size:0.0229, color:'white', align:'right'},
 		type: {name:'Type', text:'', x:0.0854, y:0.612, width:0.71, height:0.0543, oneLine:true, font:'belerenb', size:0.0279, outlineWidth:0.008, color:'white'},


### PR DESCRIPTION
Restores the fake shadow for safari compatibility into the recently added mana symbol rendering function and adjusted the set symbol outline on the Japan Showcase Nickname to follow new scaling levels and adjusted main mana symbol outline to match the base Japan Showcase outline.