### PR TITLE
Enabling Artist Only Information on card

### DIFF
--- a/creator/index.html
+++ b/creator/index.html
@@ -611,45 +611,104 @@
 								<span class='checkmark'></span>
 							</label>
 						</div>
+<!--Consolidating the Collector info style START --DSKZ ------------------------------------------------------------------------------------------------------------------>
 						<div class='readable-background padding margin-bottom'>
 							<h5 class='input-description margin-bottom'>Collector info style</h5>
-							<label class='checkbox-container input margin-bottom'>Use new (post-ONE) collector info style
-								<input id='enableNewCollectorStyle' type='checkbox' onchange='enableNewCollectorInfoStyle();'>
+							<label class='checkbox-container input margin-bottom'>Show collector info (none by default)
+								<input id='enableCollectorInfo' type='checkbox'>
 								<span class='checkmark'></span>
 							</label>
-						</div>
-						<div class='readable-background padding margin-bottom'>
-							<h5 class='input-description margin-bottom'>Show collector info</h5>
-							<label class='checkbox-container input margin-bottom'>Show collector info (uncheck to hide)
-								<input id='enableCollectorInfo' type='checkbox' onchange='enableCollectorInfo();'>
-								<span class='checkmark'></span>
-							</label>
-							<!--Section Created for issue #117. Reqeust is to only show Artist info --DSKZ -->
-							<div id='enableArtistOnly' class='hidden margin-top'>
-    							<label class='checkbox-container input'>Show artist info only
-      								<input type='checkbox' id='enableArtistOnlyCheck' onchange='setBottomInfoStyle();'>
-      								<span class='checkmark'></span>
-   								</label>
-							</div>
-							<!--Script verifies if the "Show collector info" is checked, show the second option and verify state of check marks --DSKZ -->
-							<!--If the second box is checked, display Artist only info, and if you uncheck "Show collector info", the info is reset to default-->
+								<div id='enableArtistOnly' class='hidden margin-top'>
+									<label class='checkbox-container input'>Show artist info only
+										<input type='checkbox' id='enableArtistOnlyCheck' onchange='setBottomInfoStyle();'>
+										<span class='checkmark'></span>
+									</label>
+								</div>
+								<div id='togglecheckbox' class='hidden margin-top'>
+									<label class='checkbox-container input margin-bottom'>Use new (post-ONE) collector info style
+										<input id='enableNewCollectorStyle' type='checkbox' onchange='enableNewCollectorInfoStyle();'>
+										<span class='checkmark'></span>
+									</label>
+								</div>
 							<script>
-  								const firstCheck = document.getElementById('enableCollectorInfo');
-  								const secondCheckbox = document.getElementById('enableArtistOnly');
-								const secondCheck = document.getElementById('enableArtistOnlyCheck');
-  								firstCheck.addEventListener('change', () => {
-    								if (firstCheck.checked){
-										secondCheckbox.classList.remove('hidden');
-									}else{
-										secondCheckbox.classList.add('hidden');
-										secondCheck.checked = false;
-										setBottomInfoStyle();
+								const enableCheckbox = document.getElementById('enableCollectorInfo');       // main
+								const secondCheckbox = document.getElementById('enableArtistOnly');          // container
+								const secondCheck   = document.getElementById('enableArtistOnlyCheck');      // artist-only checkbox
+								const toggleWrap    = document.getElementById('togglecheckbox');             // container
+								const toggleCheck   = document.getElementById('enableNewCollectorStyle');    // toggle checkbox
+
+								// One authoritative place that decides which function to run based on UI state
+								function setCollectorModeFromUI() {
+									// If main is off → baseline
+									if (!enableCheckbox.checked) {
+									setBottomInfoStyle();
+									return;
+									}
+									// Artist-only takes precedence → baseline
+									if (secondCheck.checked) {
+									setBottomInfoStyle();
+									return;
+									}
+									// Otherwise toggle decides
+									if (toggleCheck.checked) {
+									enableNewCollectorInfoStyle();
+									} else {
+									enableCollectorInfo();
+									}
+								}
+
+								// Main: Show collector info
+								enableCheckbox.addEventListener('change', () => {
+									if (enableCheckbox.checked) {
+									// reveal options
+									secondCheckbox.classList.remove('hidden');
+									toggleWrap.classList.remove('hidden');
+
+									// reset sub-states to defaults
+									secondCheck.checked = false;
+									toggleCheck.checked = false;
+
+									// default collector style when turning main on
+									// (use microtask so any DOM/checkbox changes above settle first)
+									queueMicrotask(setCollectorModeFromUI);
+									} else {
+									// hide + full reset
+									secondCheckbox.classList.add('hidden');
+									toggleWrap.classList.add('hidden');
+									secondCheck.checked = false;
+									toggleCheck.checked = false;
+
+									setBottomInfoStyle();
 									}
 								});
-							</script>			
-							<!--Section Created for issue #117. Reqeust is to only show Artist info --DSKZ-->
-						</div>
 
+								// Toggle: switch between old/new styles
+								toggleCheck.addEventListener('change', () => {
+									if (!enableCheckbox.checked) {
+									// main is off → snap toggle off and ignore
+									toggleCheck.checked = false;
+									return;
+									}
+									if (toggleCheck.checked) {
+									// Turning toggle ON forces artist-only OFF
+									if (secondCheck.checked) secondCheck.checked = false;
+									}
+									// Always recompute after any flips
+									queueMicrotask(setCollectorModeFromUI);
+								});
+
+								// Artist-only: takes precedence and disables toggle effect
+								secondCheck.addEventListener('change', () => {
+									if (secondCheck.checked) {
+									// artist-only ON → force toggle OFF
+									if (toggleCheck.checked) toggleCheck.checked = false;
+									}
+									// Always recompute after any flips
+									queueMicrotask(setCollectorModeFromUI);
+								});
+							</script>			
+						</div>					
+<!--Consolidating the Collector info style FINISH --DSKZ ------------------------------------------------------------------------------------------------------------------>
 						<div class='readable-background padding margin-bottom'>
 							<h5 class='padding input-description'>Serial Number (leave both blank to hide)</h5>
 							<div class='padding input-grid'>

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -5,6 +5,26 @@ if (debugging) {
 	alert('debugging - 4.0');
 	document.querySelectorAll('.debugging').forEach(element => element.classList.remove('hidden'));
 }
+//Adding a gate funtion to make sure all the fonts are properly loaded and we dont get some formatted one on teh bottom of the card --DSKZ
+async function ensureFontsLoaded() {
+  // list the faces you use in bottom info
+  const faces = [
+    '12px "gothammedium"',
+    '12px "mplantin"'
+  ];
+  try {
+    // kick off specific loads (size value required by spec)
+    await Promise.all(faces.map(f => document.fonts.load(f)));
+    // also wait until the full font set is ready
+    if (document.fonts.status !== 'loaded') {
+      await document.fonts.ready;
+    }
+  } catch (e) {
+    // ignore — worst case we draw with fallback and re-draw later
+    console.warn('Font load wait failed', e);
+  }
+}
+//Adding a gate funtion to make sure all the fonts are properly loaded and we dont get some formatted one on teh bottom of the card --DSKZ
 
 //To save the server from being overloaded? Maybe?
 function fixUri(input) {
@@ -4822,6 +4842,7 @@ async function bottomInfoEdited() {
 	card.infoNote = document.querySelector('#info-note').value;
 
 	if (document.querySelector('#enableCollectorInfo').checked) {
+		await ensureFontsLoaded(); // Calling the gate guard at the TOP of the file --DSKZ
 		for (var textObject of Object.entries(card.bottomInfo)) {
 			if (["NOT FOR SALE", "Wizards of the Coast", "CardConjurer.com", "cardconjurer.com"].some(v => textObject[1].text.includes(v))) {
 				continue;
@@ -4877,7 +4898,7 @@ function toggleStarDot() {
 function enableNewCollectorInfoStyle() {
 	localStorage.setItem('enableNewCollectorStyle', document.querySelector('#enableNewCollectorStyle').checked);
 	setBottomInfoStyle();
-	bottomInfoEdited();
+	ensureFontsLoaded().then(bottomInfoEdited); // Calling the same gate guard --DSKZ
 }
 function enableCollectorInfo() {
 	localStorage.setItem('enableCollectorInfo', document.querySelector('#enableCollectorInfo').checked);


### PR DESCRIPTION
This PR closes #117 .
-- Tested successfully within the Docker container and a local Apache Server 
-- Tweaked creator.index.html to enable a "Show artist info only" button 
-- Tweaked js/creator-23.js to properly load and render 
**NOTES**:
1- Comments tagged with "DSKZ" were done to show changes 
2- Clear your browsers cache before testing.

Button will not show up until you check the "Show collector info"
<img width="1850" height="656" alt="image" src="https://github.com/user-attachments/assets/5f2686e5-7de4-4cb6-8abe-853e8f7e4410" />

Once checked, it'll display default information:
<img width="1844" height="648" alt="image" src="https://github.com/user-attachments/assets/81ccb088-8bcd-4cb2-8693-3822b3b8b651" />

Once you click the second button, only artist info will show. I chose a specific size for the font. Can be changed later...
<img width="1858" height="641" alt="image" src="https://github.com/user-attachments/assets/d8718594-e674-4021-9c66-22e24ee2e574" />

