### PR TITLE
Fixes Hexproof.io Set Symbol Import

### DIFF
--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -4678,9 +4678,14 @@ function fetchSetSymbol() {
 	} else if (document.querySelector("#set-symbol-source").value == 'gatherer') {
 		if (setSymbolAliases.has(setCode.toLowerCase())) setCode = setSymbolAliases.get(setCode.toLowerCase());
 		uploadSetSymbol('http://gatherer.wizards.com/Handlers/Image.ashx?type=symbol&set=' + setCode + '&size=large&rarity=' + setRarity, 'resetSetSymbol');
-	} else if (document.querySelector("#set-symbol-source").value == 'hexproof') {
-		if (setSymbolAliases.has(setCode.toLowerCase())) setCode = setSymbolAliases.get(setCode.toLowerCase());
-		uploadSetSymbol('https://api.hexproof.io/symbols/set/' + setCode + '/' + setRarity, 'resetSetSymbol');
+    } else if (document.querySelector("#set-symbol-source").value == 'hexproof') {
+        if (setSymbolAliases.has(setCode.toLowerCase())) setCode = setSymbolAliases.get(setCode.toLowerCase());
+        var hexproofUrl = 'https://api.hexproof.io/symbols/set/' + setCode + '/' + setRarity;
+        // Use CORS proxy for hexproof.io
+        if (params.get('noproxy') == null) {
+            hexproofUrl = 'https://corsproxy.io/?url=' + encodeURIComponent(hexproofUrl);
+        }
+        uploadSetSymbol(hexproofUrl, 'resetSetSymbol');
 	} else {
 		var extension = 'svg';
 		if (['moc', 'ltr', 'ltc', 'cmm', 'who', 'scd', 'woe', 'wot', 'woc', 'lci', 'lcc', 'mkm', 'mkc', 'otj', 'otc', 'dft', 'drc', 'tdm', 'tdc', 'fin', 'fic', 'pio', 'om1', 'spm'].includes(setCode.toLowerCase())) {


### PR DESCRIPTION
Fixes Hexproof.io Set Symbol Import by using a CORS Proxy to retrieve the set symbols