### PR TITLE
Add Save Cards Data to Image Downloads

### DIFF
--- a/creator/index.html
+++ b/creator/index.html
@@ -703,7 +703,7 @@
 							<h5 class='padding margin-bottom input-description'>Download all saved cards</h5>
 							<button class='input margin-bottom' onclick='downloadSavedCards();'>Download All</button>
 							<h5 class='padding margin-bottom input-description'>Upload previously downloaded file of saved cards (downloaded from above)<br>Now downloaded cards have this data stored for import later. Try it out today!</h5>
-						<input type='file' accept='.cardconjurer,.txt,.png,.jpg' class='input margin-bottom' oninput='uploadSavedCards(event);'>
+						<input type='file' accept='.cardconjurer,.txt,.png,.jpeg' class='input margin-bottom' oninput='uploadSavedCards(event);'>
 							<h5 class='padding margin-bottom input-description'>Delete ALL saved cards</h5>
 							<button class='input margin-bottom' onclick='deleteSavedCards();'>Delete All</button>
 						</div>

--- a/creator/index.html
+++ b/creator/index.html
@@ -702,8 +702,8 @@
 						<div class='readable-background padding margin-bottom'>
 							<h5 class='padding margin-bottom input-description'>Download all saved cards</h5>
 							<button class='input margin-bottom' onclick='downloadSavedCards();'>Download All</button>
-							<h5 class='padding margin-bottom input-description'>Upload previously downloaded file of saved cards (downloaded from above)</h5>
-							<input type='file' accept='.cardconjurer,.txt' class='input margin-bottom' oninput='uploadSavedCards(event);'>
+							<h5 class='padding margin-bottom input-description'>Upload previously downloaded file of saved cards (downloaded from above)<br>Now downloaded cards have this data stored for import later. Try it out today!</h5>
+						<input type='file' accept='.cardconjurer,.txt,.png,.jpg' class='input margin-bottom' oninput='uploadSavedCards(event);'>
 							<h5 class='padding margin-bottom input-description'>Delete ALL saved cards</h5>
 							<button class='input margin-bottom' onclick='deleteSavedCards();'>Delete All</button>
 						</div>


### PR DESCRIPTION
Adds save card meta data to downloaded cards for import later in the save feature for future editing.
Skips art if its user uploaded (doesn't embed the art in base64 like the normal save feature) but otherwise will reimport links or URL