### PR TITLE
Toggle Title and Type overlap

### DIFF
--- a/creator/index.html
+++ b/creator/index.html
@@ -297,6 +297,12 @@
 								<span class='checkmark'></span>
 							</label>
 						</div>
+						<div class='readable-background padding margin-bottom'>
+							<label class='checkbox-container input'>Auto-avoid text overlap for Title and Type
+								<input id='auto-avoid-text-overlap' type='checkbox' checked onchange='textEdited();'>
+								<span class='checkmark'></span>
+							</label>
+						</div>
 						<div class='readable-background padding'>
 							<h5 class='padding input-description'>Add a textbox to your card</h5>
 							<div class='padding input-grid'>

--- a/js/creator-23.js
+++ b/js/creator-23.js
@@ -1241,6 +1241,7 @@ function autoFrameBuffer() {
 	autoFrameTimer = setTimeout(autoFrame, 500);
 }
 async function drawText() {
+	window.actualManaLeftEdge = undefined;
 	textContext.clearRect(0, 0, textCanvas.width, textCanvas.height);
 	prePTContext.clearRect(0, 0, prePTCanvas.width, prePTCanvas.height);
 	drawTextBetweenFrames = false;
@@ -1430,6 +1431,40 @@ function writeText(textObject, targetContext) {
 	var textManaCost = textObject.manaCost || false;
 	var textAllCaps = textObject.allCaps || false;
 	var textManaSpacing = scaleWidth(textObject.manaSpacing) || 0;
+	if (document.querySelector('#auto-avoid-text-overlap') && document.querySelector('#auto-avoid-text-overlap').checked) {
+		if (textObject.name == 'Title' && card.text.mana && card.text.mana.text) {
+			var manaText = card.text.mana.text;
+			var symbolCount = 0;
+			var inBrackets = false;
+			for (var i = 0; i < manaText.length; i++) {
+				if (manaText[i] == '{') { inBrackets = true; symbolCount++; }
+				else if (manaText[i] == '}') { inBrackets = false; }
+				else if (!inBrackets && manaText[i].trim() != '') { symbolCount++; }
+			}
+			var manaLeftEdge = window.actualManaLeftEdge;
+			if (manaLeftEdge === undefined) {
+				var mX = scaleX(card.text.mana.x) || 0;
+				var mW = scaleWidth(card.text.mana.width) || scaleWidth(1);
+				var mRightEdge = mX + mW;
+				var mSize = scaleHeight(card.text.mana.size) || scaleHeight(0.038);
+				var mSpacing = scaleWidth(card.text.mana.manaSpacing) || 0;
+				var renderedWidth = symbolCount * (mSize * 0.86 + 2 * mSpacing);
+				manaLeftEdge = (!card.text.mana.align || card.text.mana.align == 'right') ? (mRightEdge - renderedWidth) : mX;
+			}
+			if (textX + textWidth > manaLeftEdge) {
+				textWidth = Math.max(0, manaLeftEdge - textX - scaleWidth(0.005));
+			}
+		}
+		if (textObject.name == 'Type' && card.setSymbolBounds && card.setSymbolBounds.width > 0) {
+			var setSymbolLeftEdge = scaleX(card.setSymbolX);
+			if (card.setSymbolBounds.outlineWidth) {
+				setSymbolLeftEdge -= scaleHeight(card.setSymbolBounds.outlineWidth);
+			}
+			if (textX + textWidth > setSymbolLeftEdge) {
+				textWidth = Math.max(0, setSymbolLeftEdge - textX - scaleWidth(0.005));
+			}
+		}
+	}
 	//Buffers the canvases accordingly
 	var canvasMargin = 300;
 	paragraphCanvas.width = textWidth + 2 * canvasMargin;
@@ -2325,6 +2360,10 @@ function writeText(textObject, targetContext) {
 				} else {
 					trueTargetContext.drawImage(paragraphCanvas, textX - canvasMargin + ptShift[0] + permaShift[0] + finalHorizontalAdjust, textY - canvasMargin + verticalAdjust + ptShift[1] + permaShift[1]);
 				}
+				if (textObject.name == 'Mana Cost') {
+					var baseAdjust = (textAlign == 'right') ? (textWidth - widestLineWidth) : ((textAlign == 'center') ? (textWidth - widestLineWidth) / 2 : 0);
+					window.actualManaLeftEdge = textX + finalHorizontalAdjust + baseAdjust;
+				}
 				drawingText = false;
 			}
 		}
@@ -2694,6 +2733,9 @@ function setSymbolEdited() {
 	card.setSymbolY = document.querySelector('#setSymbol-y').value / card.height;
 	card.setSymbolZoom = document.querySelector('#setSymbol-zoom').value / 100;
 	drawCard();
+	if (document.querySelector('#auto-avoid-text-overlap') && document.querySelector('#auto-avoid-text-overlap').checked) {
+		drawTextBuffer();
+	}
 }
 function resetSetSymbol() {
 	if (card.setSymbolBounds == undefined) {


### PR DESCRIPTION
Adds a toggle in the Text tab that will automatically shrink title and type lines to not overlap with mana costs and set symbols.